### PR TITLE
update(kubernetes): Update manifests files template falcosidekick

### DIFF
--- a/kubernetes/falcosidekick/templates/deployment.yaml
+++ b/kubernetes/falcosidekick/templates/deployment.yaml
@@ -11,14 +11,12 @@ metadata:
     app.kubernetes.io/version: "2.28.0"
     app.kubernetes.io/part-of: falcosidekick
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: core
 spec:
   replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: falcosidekick
       app.kubernetes.io/instance: falcosidekick
-      app.kubernetes.io/component: core
       app.kubernetes.io/component: core
   template:
     metadata:
@@ -30,7 +28,6 @@ spec:
         app.kubernetes.io/version: "2.28.0"
         app.kubernetes.io/part-of: falcosidekick
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: core
       annotations:
         checksum/config: 63445e20ac0ffdb678fd8c02e2ac13469caba51712e69392192cebc3b3266abd
     spec:

--- a/kubernetes/falcosidekick/templates/rbac.yaml
+++ b/kubernetes/falcosidekick/templates/rbac.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/version: "2.28.0"
     app.kubernetes.io/part-of: falcosidekick
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: core
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -26,7 +25,6 @@ metadata:
     app.kubernetes.io/version: "2.28.0"
     app.kubernetes.io/part-of: falcosidekick
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: core
 rules:
 - apiGroups:
     - ""
@@ -48,7 +46,6 @@ metadata:
     app.kubernetes.io/version: "2.28.0"
     app.kubernetes.io/part-of: falcosidekick
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/falcosidekick/templates/secrets.yaml
+++ b/kubernetes/falcosidekick/templates/secrets.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/version: "2.28.0"
     app.kubernetes.io/part-of: falcosidekick
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: core
 type: Opaque
 data:
   # Slack Output

--- a/kubernetes/falcosidekick/templates/service.yaml
+++ b/kubernetes/falcosidekick/templates/service.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/version: "2.28.0"
     app.kubernetes.io/part-of: falcosidekick
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: core
 spec:
   type: ClusterIP
   ports:
@@ -26,6 +25,5 @@ spec:
   selector:
     app.kubernetes.io/name: falcosidekick
     app.kubernetes.io/instance: falcosidekick
-    app.kubernetes.io/component: core
     app.kubernetes.io/component: core
 ---


### PR DESCRIPTION
Updating manifests falcosidekick files (automatically generated by helm template) 

/kind update
/area manifests

Fixes #
al apply "kubectl apply -k falcosidekick"  
generate error: mapping key "app.kubernetes.io/component: core " already defined  the app.kubernetes.io/component: core is repeat 